### PR TITLE
Update: Standardization_SumAllBlock

### DIFF
--- a/Standardization/sum_all_block.ipynb
+++ b/Standardization/sum_all_block.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SUM ALL BLOCK\n",
+    "Đoạn code này tính tổng điểm của các khối thi khác nhau (A, B, C, D) cho từng thí sinh trong dữ liệu thi THPT quốc gia. Sau đó, nó xuất ra một file CSV chỉ chứa các thông tin quan trọng bao gồm SBD, tên tỉnh, và tổng điểm của các khối. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "# Load the data\n",
+    "data_df = pd.read_csv('Data/Data.csv')\n",
+    "tinh_df = pd.read_csv('Data/Tinh.csv')\n",
+    "\n",
+    "# Merge data based on 'MaTinh'\n",
+    "merged_df = pd.merge(data_df, tinh_df, on='MaTinh', how='left')\n",
+    "\n",
+    "# Tính tổng điểm của các khối\n",
+    "merged_df['Tong_Diem_Khoi_A'] = merged_df[['Toan', 'Ly', 'Hoa']].sum(axis=1, skipna=False)\n",
+    "\n",
+    "merged_df['Tong_Diem_Khoi_B'] = merged_df[['Toan', 'Sinh', 'Hoa']].sum(axis=1, skipna=False)\n",
+    "merged_df['Tong_Diem_Khoi_C'] = merged_df[['Van', 'Lich su', 'Dia ly']].sum(axis=1, skipna=False)\n",
+    "merged_df['Tong_Diem_Khoi_D'] = merged_df[['Toan', 'Van', 'Ngoai ngu']].sum(axis=1, skipna=False)\n",
+    "\n",
+    "# Lọc chỉ các cột cần thiết cho kết quả cuối cùng\n",
+    "total_scores_df = round(merged_df[['SBD', 'Tong_Diem_Khoi_A', 'Tong_Diem_Khoi_B', 'Tong_Diem_Khoi_C', 'Tong_Diem_Khoi_D', 'TenTinh']], 2)\n",
+    "\n",
+    "# Xuất kết quả ra file CSV\n",
+    "total_scores_df.to_csv('Total_Scores.csv', index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Chuẩn hóa dữ liệu : tính tổng điểm của các khối thi khác nhau (A, B, C, D) cho từng thí sinh trong dữ liệu thi THPT 

![image](https://github.com/user-attachments/assets/d887d337-6624-48be-9bc4-ba6b5348d7ef)

data_df chứa dữ liệu thi của từng thí sinh,
tinh_df chứa thông tin về các tỉnh. 
Các thông tin từ thí sinh và tỉnh đã được lọc từ công đoạn Cleaning data

![image](https://github.com/user-attachments/assets/68018253-dead-4290-93b1-4eb308136fd7)

merged_df là kết quả của việc ghép dữ liệu dựa trên mã tỉnh MaTinh, bổ sung thêm tên tỉnh vào dữ liệu của thí sinh.

![image](https://github.com/user-attachments/assets/bfb3c37f-c4e3-4811-b266-10abc5b2e168)

Đoạn mã này có chức năng tính điểm cho các khối khác nhau ( A,B,C,D )
Khối A: Toán, Lý, Hóa
Khối B: Toán, Sinh, Hóa
Khối C: Văn, Lịch sử, Địa lý
Khối D: Toán, Văn, Ngoại ngữ
-  Với skipna=False, bất kỳ giá trị thiếu nào sẽ làm cho tổng điểm của khối tương ứng bị thiếu (tránh trường hợp tính tổng điểm không chính xác nếu thiếu dữ liệu).

![image](https://github.com/user-attachments/assets/8c110a51-03ae-4fa8-86fb-4fb5221572ca)

- total_scores_df chứa các cột cần thiết: SBD (số báo danh), tổng điểm của các khối (Tong_Diem_Khoi_A, Tong_Diem_Khoi_B, Tong_Diem_Khoi_C, Tong_Diem_Khoi_D), và TenTinh (tên tỉnh).
- round(..., 2) giúp làm tròn các giá trị điểm đến 2 chữ số thập phân.

![image](https://github.com/user-attachments/assets/ae382740-1f6a-46ad-bde0-d15f9091a750)

-Kết quả cuối cùng được lưu vào file Total_Scores.csv, giúp bạn dễ dàng xem lại hoặc tiếp tục phân tích sau.






