### PR TITLE
Up file sum_pass_fail

### DIFF
--- a/Standardization/sum_pass_fail.ipynb
+++ b/Standardization/sum_pass_fail.ipynb
@@ -1,36 +1,18 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "#SUM RESULTS BY COUNTRY (2018-2019)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Kết quả đã được lưu vào: ../output/Summary_Result_By_Year.csv\n"
-     ]
-    }
-   ],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#SUM RESULTS STUDENTS BY PROVINCE (2018-2019)"
+    "# SUM RESULTS BY COUNTRY (2018-2019)\n",
+    "\n",
+    "-Phân tích và thống kê kết quả thi của thí sinh: Tính toán số môn đã thi và tổng điểm của từng thí sinh để xác định kết quả (\"Đậu\", \"Rớt\", \"Thi lại\").\n",
+    "\n",
+    "-Tổng hợp kết quả theo năm và tỉnh: Tổng hợp số lượng thí sinh đậu, rớt, và thi lại theo từng tỉnh cho hai năm 2018 và 2019. Mỗi tỉnh sẽ có thống kê chi tiết về số lượng thí sinh đạt mỗi loại kết quả trong từng năm.\n",
+    "\n",
+    "-Kết hợp với dữ liệu tỉnh: Ghép mã tỉnh với tên tỉnh để bảng kết quả dễ hiểu hơn.\n",
+    "\n",
+    "-Xuất kết quả ra file CSV: Lưu dữ liệu tổng kết vào file Summary_Result_By_Year.csv để tiện cho việc xem và sử dụng sau này. "
    ]
   },
   {
@@ -38,7 +20,67 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "# Đọc dữ liệu từ Data.csv và Tinh.csv\n",
+    "data_df = pd.read_csv('../Data/Cleaned_Data.csv')\n",
+    "tinh_df = pd.read_csv('../Data/Tinh.csv')\n",
+    "\n",
+    "# Tính tổng số môn mỗi thí sinh đã thi và tổng điểm\n",
+    "subjects = ['Toan', 'Van', 'Ly', 'Sinh', 'Ngoai ngu', 'Hoa', 'Lich su', 'Dia ly', 'GDCD']\n",
+    "data_df['Total_Score'] = data_df[subjects].sum(axis=1)\n",
+    "data_df['Subjects_Taken'] = data_df[subjects].notnull().sum(axis=1)\n",
+    "\n",
+    "# Xác định kết quả (Đậu/Rớt/Thi lại) cho mỗi thí sinh\n",
+    "conditions = [\n",
+    "    (data_df['Subjects_Taken'] <= 3),  # Thi lại nếu có <= 3 môn\n",
+    "    (data_df['Total_Score'] >= 15)     # Đậu nếu tổng điểm >= 15\n",
+    "]\n",
+    "choices = [\"Thi lại\", \"Đậu\"]\n",
+    "data_df['Result'] = np.select(conditions, choices, default=\"Rớt\")\n",
+    "\n",
+    "# Lọc dữ liệu theo năm và tính số lượng thí sinh đậu/rớt/thi lại theo tỉnh cho từng năm\n",
+    "summary_2018 = data_df[data_df['Year'] == 2018].groupby(['MaTinh', 'Result']).size().unstack(fill_value=0).reset_index()\n",
+    "summary_2018['Tổng thí sinh 2018'] = summary_2018[['Đậu', 'Rớt', 'Thi lại']].sum(axis=1)\n",
+    "\n",
+    "summary_2019 = data_df[data_df['Year'] == 2019].groupby(['MaTinh', 'Result']).size().unstack(fill_value=0).reset_index()\n",
+    "summary_2019['Tổng thí sinh 2019'] = summary_2019[['Đậu', 'Rớt', 'Thi lại']].sum(axis=1)\n",
+    "\n",
+    "# Đổi tên cột để phân biệt các năm\n",
+    "summary_2018 = summary_2018.rename(columns={\n",
+    "    'Đậu': 'Số thí sinh đậu 2018',\n",
+    "    'Rớt': 'Số thí sinh rớt 2018',\n",
+    "    'Thi lại': 'Số thí sinh thi lại 2018'\n",
+    "})\n",
+    "\n",
+    "summary_2019 = summary_2019.rename(columns={\n",
+    "    'Đậu': 'Số thí sinh đậu 2019',\n",
+    "    'Rớt': 'Số thí sinh rớt 2019',\n",
+    "    'Thi lại': 'Số thí sinh thi lại 2019'\n",
+    "})\n",
+    "\n",
+    "# Hợp nhất dữ liệu của hai năm 2018 và 2019\n",
+    "summary_df = pd.merge(summary_2018, summary_2019, on='MaTinh', how='outer').fillna(0)\n",
+    "\n",
+    "# Thêm tên tỉnh vào bảng tổng kết\n",
+    "summary_df = pd.merge(summary_df, tinh_df, on='MaTinh', how='left').rename(columns={'TenTinh': 'Tên Tỉnh'})\n",
+    "\n",
+    "# Xuất kết quả ra file CSV\n",
+    "summary_file_path = '../output/Summary_Result_By_Year.csv'\n",
+    "summary_df.to_csv(summary_file_path, index=False)\n",
+    "\n",
+    "# Hiển thị thông tin\n",
+    "print(\"Kết quả đã được lưu vào:\", summary_file_path)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SUM RESULTS STUDENTS BY PROVINCE (2018-2019)"
+   ]
   }
  ],
  "metadata": {
@@ -57,7 +99,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Đọc dữ liệu từ các tệp CSV:
-Sử dụng pd.read_csv để đọc dữ liệu từ Cleaned_Data.csv và Tinh.csv vào các DataFrame data_df và tinh_df.
-Data.csv chứa thông tin của từng thí sinh về các môn thi và điểm số.
Tinh.csv chứa mã tỉnh (MaTinh) và tên tỉnh (TenTinh).
![image](https://github.com/user-attachments/assets/57ff1fa1-2886-46c8-a471-daaf307aa794)

Tính tổng số môn và tổng điểm của mỗi thí sinh:
-subjects là danh sách các môn học mà thí sinh có thể đã thi.
-data_df['Total_Score'] tính tổng điểm cho mỗi thí sinh bằng cách cộng tất cả điểm của các môn trong subjects.
-data_df['Subjects_Taken'] đếm số môn mỗi thí sinh đã tham gia thi (không tính môn bị null).
![image](https://github.com/user-attachments/assets/5cd6eeb8-f53e-4cee-a8cd-f1c96527a2be)

Xác định kết quả của từng thí sinh:
-Dựa trên điều kiện:
+Thí sinh "Thi lại" nếu thi ≤ 3 môn.
+Thí sinh "Đậu" nếu tổng điểm ≥ 15.
-np.select dùng để xác định kết quả của từng thí sinh và gán giá trị "Thi lại", "Đậu", hoặc "Rớt" vào cột Result.
![image](https://github.com/user-attachments/assets/0002757a-b237-4856-8494-99b9c84a785b)

Lọc và tính toán kết quả theo tỉnh cho từng năm:
-summary_2018 và summary_2019 lọc dữ liệu thí sinh theo năm 2018 và 2019, sau đó tính số lượng thí sinh theo Result (Đậu, Rớt, Thi lại) và theo MaTinh.
-unstack(fill_value=0) chuyển các kết quả "Đậu", "Rớt", "Thi lại" thành cột và điền giá trị 0 nếu không có thí sinh nào đạt kết quả đó.
-Thêm cột Tổng thí sinh cho mỗi năm bằng cách cộng tổng các thí sinh trong các cột "Đậu", "Rớt", và "Thi lại".
![image](https://github.com/user-attachments/assets/365e2133-8af8-46ec-b63f-babd35a5ef19)

Đổi tên cột để phân biệt các năm:
-rename(columns=...) đổi tên cột của summary_2018 và summary_2019 để phân biệt số lượng thí sinh đậu/rớt/thi lại của mỗi năm (2018, 2019).
![image](https://github.com/user-attachments/assets/4d17e796-2e58-438e-a439-32fe599ef3c2)

Hợp nhất dữ liệu của hai năm 2018 và 2019:
-pd.merge hợp nhất summary_2018 và summary_2019 theo mã tỉnh (MaTinh) và điền giá trị 0 cho những giá trị còn thiếu (fillna(0)).
![image](https://github.com/user-attachments/assets/c6e57fe6-16a3-4a11-a328-dacfe17a4ab5)

Thêm tên tỉnh vào bảng tổng kết:
-pd.merge hợp nhất dữ liệu summary_df với tinh_df dựa trên MaTinh để thêm tên tỉnh vào kết quả cuối cùng.
-Đổi tên TenTinh thành Tên Tỉnh để dễ đọc.
![image](https://github.com/user-attachments/assets/6ba4d3f7-afec-4160-8e9d-a349c35648dd)

Xuất kết quả ra file CSV:
-to_csv xuất bảng tổng kết summary_df thành file Summary_Result_By_Year.csv trong thư mục ../output/.
![image](https://github.com/user-attachments/assets/878f4c8e-78e7-4394-a30b-7de97bbde534)

Hiển thị thông báo:
-print hiển thị đường dẫn nơi file kết quả được lưu.
![image](https://github.com/user-attachments/assets/262146c6-1d9c-48e1-bd9d-e01f59f89fe7)

