### PR TITLE
Feature/standardization sum pass and fail

### DIFF
--- a/Standardization/pass_or_fail.ipynb
+++ b/Standardization/pass_or_fail.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pass or fail\n",
+    "\n",
+    "Phân tích kết quả thi của học sinh, xác định trạng thái đậu/rớt, và xuất danh sách kết quả chi tiết vào một file CSV."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "# Load data\n",
+    "data_df = pd.read_csv('Data/Data.csv')\n",
+    "tinh_df = pd.read_csv('Data/Tinh.csv')\n",
+    "\n",
+    "# Merge data based on 'MaTinh'\n",
+    "merged_df = pd.merge(data_df, tinh_df, on='MaTinh', how='left')\n",
+    "\n",
+    "# Calculate the total score across all subjects for each student\n",
+    "merged_df['Total_Score'] = merged_df[['Toan', 'Van', 'Ly', 'Sinh', 'Ngoai ngu', 'Hoa', 'Lich su', 'Dia ly', 'GDCD']].sum(axis=1, skipna=True)\n",
+    "\n",
+    "# Count the number of subjects each student has taken\n",
+    "merged_df['Subjects_Taken'] = merged_df[['Toan', 'Van', 'Ly', 'Sinh', 'Ngoai ngu', 'Hoa', 'Lich su', 'Dia ly', 'GDCD']].notnull().sum(axis=1)\n",
+    "\n",
+    "# Label students with 3 or fewer subjects as \"Thí sinh thi lại\"\n",
+    "merged_df['Ket_Qua'] = merged_df['Subjects_Taken'].apply(lambda x: \"Thí sinh thi lại\" if x <= 3 else None)\n",
+    "\n",
+    "# Determine pass/fail for students with more than 3 subjects\n",
+    "# Assuming a passing score threshold (e.g., 15)\n",
+    "passing_score = 15\n",
+    "merged_df['Ket_Qua'] = merged_df.apply(\n",
+    "    lambda row: \"Đậu\" if row['Total_Score'] >= passing_score and row['Ket_Qua'] is None else \n",
+    "                (\"Rớt\" if row['Ket_Qua'] is None else row['Ket_Qua']),\n",
+    "    axis=1\n",
+    ")\n",
+    "\n",
+    "# Select relevant columns for the final output\n",
+    "result_df = round(merged_df[['SBD', 'Total_Score', 'Subjects_Taken', 'Ket_Qua', 'TenTinh']], 2)\n",
+    "\n",
+    "# Export to CSV\n",
+    "result_df.to_csv('Pass_Fail_List.csv', index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Standardization/sum_pass_fail.ipynb
+++ b/Standardization/sum_pass_fail.ipynb
@@ -25,7 +25,7 @@
     "import numpy as np\n",
     "\n",
     "# Đọc dữ liệu từ Data.csv và Tinh.csv\n",
-    "data_df = pd.read_csv('../Data/Cleaned_Data.csv')\n",
+    "data_df = pd.read_csv('../Data/Cleaning-Data.csv')\n",
     "tinh_df = pd.read_csv('../Data/Tinh.csv')\n",
     "\n",
     "# Tính tổng số môn mỗi thí sinh đã thi và tổng điểm\n",
@@ -79,7 +79,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# SUM RESULTS STUDENTS BY PROVINCE (2018-2019)"
+    "# SUM RESULTS STUDENTS BY PROVINCE (2018-2019)\n",
+    "\n",
+    "-Đếm và hiển thị số lượng thí sinh tham gia thi trong hai năm 2018 và 2019 dựa trên dữ liệu từ file Cleaned_Data.csv."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "# Đọc dữ liệu từ Data.csv\n",
+    "data_df = pd.read_csv('Data/Cleaned_Data.csv')\n",
+    "\n",
+    "# Tính tổng số thí sinh cho năm 2018 và năm 2019\n",
+    "total_students_2018 = data_df[data_df['Year'] == 2018].shape[0]\n",
+    "total_students_2019 = data_df[data_df['Year'] == 2019].shape[0]\n",
+    "\n",
+    "# Tổng thí sinh cho cả hai năm\n",
+    "total_students = total_students_2018 + total_students_2019\n",
+    "\n",
+    "# Hiển thị thông tin\n",
+    "print(\"Tổng số thí sinh năm 2018:\", total_students_2018)\n",
+    "print(\"Tổng số thí sinh năm 2019:\", total_students_2019)\n",
+    "print(\"Tổng số thí sinh của cả hai năm 2018 và 2019:\", total_students)"
    ]
   }
  ],


### PR DESCRIPTION
Tải dữ liệu: Đọc hai file CSV, Data.csv (chứa điểm thi của học sinh) và Tinh.csv (chứa thông tin tỉnh của học sinh), lưu vào các DataFrame là data_df và tinh_df.
![image](https://github.com/user-attachments/assets/24b71a82-dff4-4857-9734-145ac20d5bfd)

Gộp dữ liệu: Gộp hai bảng data_df và tinh_df dựa trên cột chung là MaTinh, sử dụng kiểu gộp left join để thêm thông tin tỉnh (TenTinh) cho từng học sinh trong data_df.
![image](https://github.com/user-attachments/assets/d1ce61e7-4c3f-4073-92b8-5f59de521475)

Tính tổng điểm: Tính tổng điểm của tất cả các môn thi (Toán, Văn, Lý, Sinh, Ngoại ngữ, Hóa, Lịch sử, Địa lý, GDCD) của từng học sinh và lưu kết quả vào cột mới Total_Score.
![image](https://github.com/user-attachments/assets/62921442-ca4f-46c2-8ff4-fabaf93d34bb)

Đếm số môn đã thi: Đếm số môn mà mỗi học sinh đã tham gia thi (các giá trị không null) và lưu vào cột Subjects_Taken.
![image](https://github.com/user-attachments/assets/7de13998-cdb3-4aac-bcf0-9f23decf4115)

Gán nhãn thi lại: Với học sinh thi 3 môn trở xuống, gán nhãn là "Thí sinh thi lại" trong cột Ket_Qua.
![image](https://github.com/user-attachments/assets/bc6b3339-4755-4995-b695-9b32fd5206c7)

Xác định đậu/rớt: Với học sinh thi nhiều hơn 3 môn, kiểm tra xem tổng điểm (Total_Score) của họ có lớn hơn hoặc bằng ngưỡng điểm đậu (đặt là 15) hay không. Nếu đạt ngưỡng, học sinh được đánh dấu là "Đậu", ngược lại là "Rớt".
![image](https://github.com/user-attachments/assets/d830bd83-9e46-4d42-a93c-e41c8cfa833f)

Chọn và xuất kết quả: Chọn các cột cần thiết (SBD, Total_Score, Subjects_Taken, Ket_Qua, TenTinh), làm tròn đến hai chữ số thập phân, và lưu kết quả cuối cùng vào file Pass_Fail_List.csv.
![image](https://github.com/user-attachments/assets/3a9a5d55-db7f-4fbe-8916-655db7978f1f)

